### PR TITLE
Update the filesystem with book metadata changes

### DIFF
--- a/book.go
+++ b/book.go
@@ -67,12 +67,12 @@ func (bf *BookFile) Filename(tmpl *template.Template, book *Book) (string, error
 
 // CalculateHash calculates the hash of b.OriginalFilename and updates book.Hash.
 // If a value is stored in the user.hash xattr, that value will be used instead of hashing the file's contents.
-func (b *BookFile) CalculateHash() error {
-	if data, err := xattr.Get(b.OriginalFilename, "user.hash"); err == nil {
-		b.Hash = string(data)
+func (bf *BookFile) CalculateHash() error {
+	if data, err := xattr.Get(bf.OriginalFilename, "user.hash"); err == nil {
+		bf.Hash = string(data)
 		return nil
 	}
-	fp, err := os.Open(b.OriginalFilename)
+	fp, err := os.Open(bf.OriginalFilename)
 	if err != nil {
 		return errors.Wrap(err, "Calculate hash")
 	}
@@ -84,7 +84,7 @@ func (b *BookFile) CalculateHash() error {
 		return errors.Wrap(err, "Calculate hash")
 	}
 	hash := fmt.Sprintf("%x", hasher.Sum(nil))
-	b.Hash = hash
+	bf.Hash = hash
 	return nil
 }
 

--- a/book.go
+++ b/book.go
@@ -108,6 +108,7 @@ func ParseFilename(filename string, re *regexp.Regexp) (Book, bool) {
 	return result, true
 }
 
+// Escape replaces special characters in a filename with _.
 func Escape(filename string) string {
 	replacements := []string{"\\", "/", ":", "*", "?", "\"", "<", ">", "|"}
 

--- a/book.go
+++ b/book.go
@@ -107,3 +107,13 @@ func ParseFilename(filename string, re *regexp.Regexp) (Book, bool) {
 	result.Files = append(result.Files, bf)
 	return result, true
 }
+
+func Escape(filename string) string {
+	replacements := []string{"\\", "/", ":", "*", "?", "\"", "<", ">", "|"}
+
+	newFilename := filename
+	for _, r := range replacements {
+		newFilename = strings.Replace(newFilename, r, "_", -1)
+	}
+	return newFilename
+}

--- a/cmd/books/commands/edit.go
+++ b/cmd/books/commands/edit.go
@@ -12,9 +12,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"text/template"
 
 	"github.com/peterh/liner"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/tspivey/books"
 	"github.com/tspivey/books/cmd/books/edit"
 )
@@ -85,17 +87,23 @@ func editFunc(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	books, err := library.GetBooksByID([]int64{int64(bookID)})
+	foundBooks, err := library.GetBooksByID([]int64{int64(bookID)})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error getting books by ID: %s", err)
 		os.Exit(1)
 	}
-	if len(books) == 0 {
+	if len(foundBooks) == 0 {
 		fmt.Fprintf(os.Stderr, "Book not found.\n")
 		os.Exit(1)
 	}
-	book := books[0]
-	parser := edit.NewParser(&book, library)
+	book := foundBooks[0]
+	outputTmplSrc := viper.GetString("output_template")
+	outputTmpl, err := template.New("filename").Funcs(template.FuncMap{"ToUpper": strings.ToUpper, "join": strings.Join, "escape": books.Escape}).Parse(outputTmplSrc)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot parse output template: %s\n\n%s\n", err, outputTmplSrc)
+		os.Exit(1)
+	}
+	parser := edit.NewParser(&book, library, outputTmpl)
 	parser.RunCommand("show", "")
 	line := liner.NewLiner()
 	defer line.Close()

--- a/cmd/books/commands/edit.go
+++ b/cmd/books/commands/edit.go
@@ -98,7 +98,7 @@ func editFunc(cmd *cobra.Command, args []string) {
 	}
 	book := foundBooks[0]
 	outputTmplSrc := viper.GetString("output_template")
-	outputTmpl, err := template.New("filename").Funcs(template.FuncMap{"ToUpper": strings.ToUpper, "join": strings.Join, "escape": books.Escape}).Parse(outputTmplSrc)
+	outputTmpl, err := template.New("filename").Funcs(funcMap).Parse(outputTmplSrc)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot parse output template: %s\n\n%s\n", err, outputTmplSrc)
 		os.Exit(1)

--- a/cmd/books/commands/import.go
+++ b/cmd/books/commands/import.go
@@ -88,7 +88,10 @@ func importFunc(cmd *cobra.Command, args []string) {
 	}
 
 	metadataParserMap = make(map[string]books.MetadataParser)
-	metadataParserMap["regexp"] = &books.RegexpMetadataParser{compiled, regexpNames}
+	metadataParserMap["regexp"] = &books.RegexpMetadataParser{
+		Regexps:     compiled,
+		RegexpNames: regexpNames,
+	}
 	metadataParserMap["epub"] = &books.EpubMetadataParser{}
 	metadataParsers = viper.GetStringSlice("default_metadata_parsers")
 	for _, name := range metadataParsers {

--- a/cmd/books/commands/import.go
+++ b/cmd/books/commands/import.go
@@ -104,7 +104,7 @@ func importFunc(cmd *cobra.Command, args []string) {
 	log.Printf("Using metadata parsers: %v\n", metadataParsers)
 	outputTmplSrc := viper.GetString("output_template")
 	var err error
-	outputTmpl, err = template.New("filename").Funcs(template.FuncMap{"ToUpper": strings.ToUpper, "join": strings.Join, "escape": books.Escape}).Parse(outputTmplSrc)
+	outputTmpl, err = template.New("filename").Funcs(funcMap).Parse(outputTmplSrc)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot parse output template: %s\n\n%s\n", err, outputTmplSrc)
 		os.Exit(1)

--- a/cmd/books/commands/import.go
+++ b/cmd/books/commands/import.go
@@ -104,7 +104,7 @@ func importFunc(cmd *cobra.Command, args []string) {
 	log.Printf("Using metadata parsers: %v\n", metadataParsers)
 	outputTmplSrc := viper.GetString("output_template")
 	var err error
-	outputTmpl, err = template.New("filename").Funcs(template.FuncMap{"ToUpper": strings.ToUpper, "join": strings.Join, "escape": escape}).Parse(outputTmplSrc)
+	outputTmpl, err = template.New("filename").Funcs(template.FuncMap{"ToUpper": strings.ToUpper, "join": strings.Join, "escape": books.Escape}).Parse(outputTmplSrc)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot parse output template: %s\n\n%s\n", err, outputTmplSrc)
 		os.Exit(1)
@@ -180,20 +180,14 @@ func importBook(filename string, library *books.Library) error {
 		return errors.Wrap(err, "Calculate book hash")
 	}
 
-	s, err := bf.Filename(outputTmpl, &book)
+	// CurrentFilename needs to be set so updateFilenames can copy/move the original file
+	bf.CurrentFilename, err = filepath.Abs(bf.OriginalFilename)
 	if err != nil {
-		return errors.Wrap(err, "Calculate output filename for book")
+		return errors.Wrap(err, "get absolute path")
 	}
-	s = truncateFilename(s)
-	newFilename := books.GetUniqueName(filepath.Join(booksRoot, s))
-	bf.CurrentFilename, err = filepath.Rel(booksRoot, newFilename)
-	if err != nil {
-		return errors.Wrap(err, "get new book filename")
-	}
-	bf.CurrentFilename = strings.Replace(bf.CurrentFilename, string(filepath.Separator), "/", -1)
 	book.Files = append(book.Files, bf)
 
-	if err := library.ImportBook(book, viper.GetBool("move")); err != nil {
+	if err := library.ImportBook(book, outputTmpl, viper.GetBool("move")); err != nil {
 		return errors.Wrap(err, "Import book into library")
 	}
 
@@ -217,41 +211,4 @@ func splitTags(filename string) []string {
 		tags = append([]string{match[2]}, tags...)
 	}
 	return tags
-}
-
-func escape(filename string) string {
-	replacements := []string{"\\", "/", ":", "*", "?", "\"", "<", ">", "|"}
-
-	newFilename := filename
-	for _, r := range replacements {
-		newFilename = strings.Replace(newFilename, r, "_", -1)
-	}
-	return newFilename
-}
-
-func truncateFilename(fn string) string {
-	var lst []string
-	dirs, fn := path.Split(fn)
-	if dirs != "" {
-		dirs = strings.TrimRight(dirs, string(os.PathSeparator))
-		lst = strings.Split(dirs, string(os.PathSeparator))
-	}
-	for i, f := range lst {
-		if len(f) <= 255 {
-			continue
-		}
-
-		l := len(f)
-		if l > 255 {
-			l = 255
-		}
-		lst[i] = f[:l]
-	}
-	if len(fn) > 250 {
-		ext := path.Ext(fn)
-		nameLen := 250 - len(ext)
-		fn = fn[:nameLen] + ext
-	}
-	lst = append(lst, fn)
-	return strings.Join(lst, string(os.PathSeparator))
 }

--- a/cmd/books/commands/match.go
+++ b/cmd/books/commands/match.go
@@ -88,7 +88,7 @@ func matchFunc(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(os.Stderr, "Using metadata parsers: %v\n", metadataParsers)
 	outputTmplSrc := viper.GetString("output_template")
 	var err error
-	outputTmpl, err = template.New("filename").Funcs(template.FuncMap{"ToUpper": strings.ToUpper, "join": strings.Join, "escape": escape}).Parse(outputTmplSrc)
+	outputTmpl, err = template.New("filename").Funcs(template.FuncMap{"ToUpper": strings.ToUpper, "join": strings.Join, "escape": books.Escape}).Parse(outputTmplSrc)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot parse output template: %s\n\n%s\n", err, outputTmplSrc)
 		os.Exit(1)
@@ -162,7 +162,7 @@ func searchDupe(filename string, library *books.Library) error {
 	if err != nil {
 		return errors.Wrap(err, "Calculate output filename for book")
 	}
-	s = truncateFilename(s)
+	s = books.TruncateFilename(s)
 	newFilename := books.GetUniqueName(filepath.Join(booksRoot, s))
 	bf.CurrentFilename, err = filepath.Rel(booksRoot, newFilename)
 	if err != nil {

--- a/cmd/books/commands/match.go
+++ b/cmd/books/commands/match.go
@@ -72,7 +72,10 @@ func matchFunc(cmd *cobra.Command, args []string) {
 	}
 
 	metadataParserMap = make(map[string]books.MetadataParser)
-	metadataParserMap["regexp"] = &books.RegexpMetadataParser{compiled, regexpNames}
+	metadataParserMap["regexp"] = &books.RegexpMetadataParser{
+		Regexps:     compiled,
+		RegexpNames: regexpNames,
+	}
 	metadataParserMap["epub"] = &books.EpubMetadataParser{}
 	metadataParsers = viper.GetStringSlice("default_metadata_parsers")
 	for _, name := range metadataParsers {

--- a/cmd/books/commands/match.go
+++ b/cmd/books/commands/match.go
@@ -163,7 +163,10 @@ func searchDupe(filename string, library *books.Library) error {
 		return errors.Wrap(err, "Calculate output filename for book")
 	}
 	s = books.TruncateFilename(s)
-	newFilename := books.GetUniqueName(filepath.Join(booksRoot, s))
+	newFilename, err := books.GetUniqueName(filepath.Join(booksRoot, s))
+	if err != nil {
+		return errors.Wrap(err, "get unique filename")
+	}
 	bf.CurrentFilename, err = filepath.Rel(booksRoot, newFilename)
 	if err != nil {
 		return errors.Wrap(err, "get new book filename")

--- a/cmd/books/commands/merge.go
+++ b/cmd/books/commands/merge.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"strings"
 	"text/template"
 
 	"fmt"
@@ -65,7 +64,7 @@ func mergeFunc(cmd *cobra.Command, args []string) {
 	}
 
 	outputTmplSrc := viper.GetString("output_template")
-	outputTmpl, err := template.New("filename").Funcs(template.FuncMap{"ToUpper": strings.ToUpper, "join": strings.Join, "escape": books.Escape}).Parse(outputTmplSrc)
+	outputTmpl, err := template.New("filename").Funcs(funcMap).Parse(outputTmplSrc)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot parse output template: %s\n\n%s\n", err, outputTmplSrc)
 		os.Exit(1)

--- a/cmd/books/commands/merge.go
+++ b/cmd/books/commands/merge.go
@@ -59,7 +59,7 @@ func mergeFunc(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error getting books by ID: %s\n", err)
 		os.Exit(1)
 	} else if len(bks) != len(ids) {
-		fmt.Fprintln(os.Stderr, "All specified book IDs must exist.\n")
+		fmt.Fprintln(os.Stderr, "All specified book IDs must exist.")
 		os.Exit(1)
 	}
 

--- a/cmd/books/commands/root.go
+++ b/cmd/books/commands/root.go
@@ -16,6 +16,7 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/tspivey/books"
 )
 
 var cfgDir string
@@ -28,6 +29,9 @@ var funcMap = template.FuncMap{
 		return i + 1
 	},
 	"joinNaturally": joinNaturally,
+	"ToUpper":       strings.ToUpper,
+	"join":          strings.Join,
+	"escape":        books.Escape,
 }
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/books/commands/update.go
+++ b/cmd/books/commands/update.go
@@ -56,7 +56,7 @@ func updateFunc(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error getting books by ID: %s\n", err)
 		os.Exit(1)
 	} else if len(bks) == 0 {
-		fmt.Fprintln(os.Stderr, "Book not found.\n")
+		fmt.Fprintln(os.Stderr, "Book not found.")
 		os.Exit(1)
 	}
 

--- a/cmd/books/edit/edit.go
+++ b/cmd/books/edit/edit.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"text/template"
 
 	"github.com/tspivey/books"
 )
@@ -26,9 +27,10 @@ type DefaultCommand struct {
 
 // Parser contains the set of available commands, and the shared state for those commands.
 type Parser struct {
-	book     *books.Book
-	lib      *books.Library
-	commands map[string]*DefaultCommand
+	book           *books.Book
+	lib            *books.Library
+	OutputTemplate *template.Template
+	commands       map[string]*DefaultCommand
 }
 
 // RunCommand runs a command with the given arguments, returning ErrUnknownCommand if not found.
@@ -122,7 +124,7 @@ var seriesCmd = &DefaultCommand{
 var saveCmd = &DefaultCommand{
 	Help: "Saves the currently edited book",
 	Run: func(cmd *DefaultCommand, args string) {
-		err := cmd.parser.lib.UpdateBook(*cmd.parser.book, true)
+		err := cmd.parser.lib.UpdateBook(*cmd.parser.book, cmd.parser.OutputTemplate, true)
 		if bee, ok := err.(books.BookExistsError); ok {
 			if args == "-m" {
 				err := cmd.parser.lib.MergeBooks([]int64{bee.BookID, cmd.parser.book.ID})
@@ -197,10 +199,11 @@ var quitCmd = &DefaultCommand{
 }
 
 // NewParser creates a new parser.
-func NewParser(book *books.Book, lib *books.Library) *Parser {
+func NewParser(book *books.Book, lib *books.Library, tmpl *template.Template) *Parser {
 	parser := &Parser{
-		book: book,
-		lib:  lib,
+		book:           book,
+		lib:            lib,
+		OutputTemplate: tmpl,
 	}
 
 	// Return a copy of a DefaultCommand  with a parser and completer added.

--- a/cmd/books/edit/edit.go
+++ b/cmd/books/edit/edit.go
@@ -127,7 +127,7 @@ var saveCmd = &DefaultCommand{
 		err := cmd.parser.lib.UpdateBook(*cmd.parser.book, cmd.parser.OutputTemplate, true)
 		if bee, ok := err.(books.BookExistsError); ok {
 			if args == "-m" {
-				err := cmd.parser.lib.MergeBooks([]int64{bee.BookID, cmd.parser.book.ID})
+				err := cmd.parser.lib.MergeBooks([]int64{bee.BookID, cmd.parser.book.ID}, cmd.parser.OutputTemplate)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Error merging books: %v\n", err)
 					return

--- a/fs.go
+++ b/fs.go
@@ -1,0 +1,130 @@
+package books
+
+import (
+	"io"
+	"log"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func TruncateFilename(fn string) string {
+	var lst []string
+	dirs, fn := path.Split(fn)
+	if dirs != "" {
+		dirs = strings.TrimRight(dirs, string(os.PathSeparator))
+		lst = strings.Split(dirs, string(os.PathSeparator))
+	}
+	for i, f := range lst {
+		if len(f) <= 255 {
+			continue
+		}
+
+		l := len(f)
+		if l > 255 {
+			l = 255
+		}
+		lst[i] = f[:l]
+	}
+	if len(fn) > 250 {
+		ext := path.Ext(fn)
+		nameLen := 250 - len(ext)
+		fn = fn[:nameLen] + ext
+	}
+	lst = append(lst, fn)
+	return strings.Join(lst, string(os.PathSeparator))
+}
+
+// moveOrCopyFile moves or copies a file from book.OriginalFilename to book.CurrentFilename, relative to the configured books root.
+// All necessary directories to make the destination valid will be created.
+func moveOrCopyFile(origName, newName string, move bool) error {
+	err := os.MkdirAll(path.Dir(newName), 0755)
+	if err != nil {
+		return err
+	}
+
+	if move {
+		err = moveFile(origName, newName)
+	} else {
+		err = copyFile(origName, newName)
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// copyFile copies a file from src to dst, setting dst's modified time to that of src.
+func copyFile(src, dst string) (e error) {
+	fp, err := os.Open(src)
+	if err != nil {
+		return errors.Wrap(err, "Copy file")
+	}
+	defer fp.Close()
+
+	st, err := fp.Stat()
+	if err != nil {
+		return errors.Wrap(err, "Copy file")
+	}
+
+	fd, err := os.Create(dst)
+	if err != nil {
+		return errors.Wrap(err, "Copy file")
+	}
+	defer func() {
+		if err := fd.Close(); err != nil {
+			e = errors.Wrap(err, "Copy file")
+		}
+		_ = os.Chtimes(dst, time.Now(), st.ModTime())
+	}()
+
+	if _, err := io.Copy(fd, fp); err != nil {
+		return errors.Wrap(err, "Copy file")
+	}
+
+	log.Printf("Copied %s to %s", src, dst)
+
+	return nil
+}
+
+// moveFile moves a file from src to dst.
+// First, moveFile will attempt to rename the file,
+// and if that fails, it will perform a copy and delete.
+func moveFile(src, dst string) error {
+	if err := os.Rename(src, dst); err != nil {
+		err = copyFile(src, dst)
+		if err != nil {
+			return err
+		}
+		err = os.Remove(src)
+		if err != nil {
+			log.Printf("Error removing %s: %s", src, err)
+			return nil
+		}
+
+		log.Printf("Moved %s to %s (copy/delete)", src, dst)
+		return nil
+	}
+
+	log.Printf("Moved %s to %s", src, dst)
+	return nil
+}
+
+// GetUniqueName checks to see if a file named f already exists, and if so, finds a unique name.
+func GetUniqueName(f string) string {
+	i := 1
+	ext := path.Ext(f)
+	newName := f
+	_, err := os.Stat(newName)
+	for err == nil {
+		newName = strings.TrimSuffix(f, ext) + " (" + strconv.Itoa(i) + ")" + ext
+		i++
+		_, err = os.Stat(newName)
+	}
+	return newName
+}

--- a/fs.go
+++ b/fs.go
@@ -13,7 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// TruncateFilename truncates fn to 255 characters.
+// TruncateFilename truncates each path segment to 255 bytes.
+// The filename portion before the extension is truncated to 250 bytes to leave room for getUniqueFilename.
 func TruncateFilename(fn string) string {
 	var lst []string
 	dirs, fn := path.Split(fn)
@@ -26,12 +27,9 @@ func TruncateFilename(fn string) string {
 			continue
 		}
 
-		l := len(f)
-		if l > 255 {
-			l = 255
-		}
-		lst[i] = f[:l]
+		lst[i] = f[:255]
 	}
+
 	if len(fn) > 250 {
 		ext := path.Ext(fn)
 		nameLen := 250 - len(ext)
@@ -50,11 +48,9 @@ func moveOrCopyFile(origName, newName string, move bool) error {
 	}
 
 	if move {
-		err = moveFile(origName, newName)
-	} else {
-		err = copyFile(origName, newName)
+		return moveFile(origName, newName)
 	}
-	return err
+	return copyFile(origName, newName)
 }
 
 // copyFile copies a file from src to dst, setting dst's modified time to that of src.

--- a/fs.go
+++ b/fs.go
@@ -14,7 +14,8 @@ import (
 )
 
 // TruncateFilename truncates each path segment to 255 bytes.
-// The filename portion before the extension is truncated to 250 bytes to leave room for getUniqueFilename.
+// The filename portion is truncated to 250 bytes to leave room for getUniqueFilename,
+// and bytes are removed just before the extension.
 func TruncateFilename(fn string) string {
 	var lst []string
 	dirs, fn := path.Split(fn)

--- a/library.go
+++ b/library.go
@@ -691,6 +691,7 @@ func (lib *Library) UpdateBook(book Book, tmpl *template.Template, updateSeries 
 	return nil
 }
 
+// GetBookIDByTitleAndAuthors gets an existing book ID with the given title and authors.
 func (lib *Library) GetBookIDByTitleAndAuthors(title string, authors []string) (int64, bool, error) {
 	tx, err := lib.Begin()
 	if err != nil {
@@ -813,7 +814,10 @@ func (lib *Library) updateFilenames(tx *sql.Tx, book Book, tmpl *template.Templa
 		if bf.CurrentFilename == newFn {
 			continue
 		}
-		newPath := GetUniqueName(filepath.Join(lib.booksRoot, newFn))
+		newPath, err := GetUniqueName(filepath.Join(lib.booksRoot, newFn))
+		if err != nil {
+			return errors.Wrap(err, "get unique name")
+		}
 		relPath, err := filepath.Rel(lib.booksRoot, newPath)
 		if err != nil {
 			return errors.Wrap(err, "get relative path")

--- a/library.go
+++ b/library.go
@@ -147,7 +147,7 @@ func (lib *Library) ImportBook(book Book, tmpl *template.Template, move bool) er
 	if len(book.Files) != 1 {
 		return errors.New("Book to import must contain only one file")
 	}
-	bf := book.Files[0]
+	bf := &book.Files[0]
 	tx, err := lib.Begin()
 	if err != nil {
 		return err
@@ -215,7 +215,7 @@ func (lib *Library) ImportBook(book Book, tmpl *template.Template, move bool) er
 	book.Files[0].ID = id
 
 	for _, tag := range bf.Tags {
-		if err := insertTag(tx, tag, &bf); err != nil {
+		if err := insertTag(tx, tag, bf); err != nil {
 			tx.Rollback()
 			return errors.Wrapf(err, "inserting tag %s", tag)
 		}

--- a/library.go
+++ b/library.go
@@ -811,6 +811,10 @@ func (lib *Library) updateFilenames(tx *sql.Tx, book Book, tmpl *template.Templa
 			continue
 		}
 		newPath := GetUniqueName(filepath.Join(lib.booksRoot, newFn))
+		relPath, err := filepath.Rel(lib.booksRoot, newPath)
+		if err != nil {
+			return errors.Wrap(err, "get relative path")
+		}
 		var cf string
 		if filepath.IsAbs(bf.CurrentFilename) {
 			// Importing this book
@@ -821,7 +825,7 @@ func (lib *Library) updateFilenames(tx *sql.Tx, book Book, tmpl *template.Templa
 		if err := moveOrCopyFile(cf, newPath, move); err != nil {
 			return errors.Wrap(err, "move or copy file")
 		}
-		if _, err := tx.Exec("update files set updated_on=datetime(), filename=? where id=?", newPath, bf.ID); err != nil {
+		if _, err := tx.Exec("update files set updated_on=datetime(), filename=? where id=?", relPath, bf.ID); err != nil {
 			return errors.Wrap(err, "updating file")
 		}
 	}

--- a/metadata.go
+++ b/metadata.go
@@ -28,6 +28,7 @@ type RegexpMetadataParser struct {
 	RegexpNames []string
 }
 
+// Parse parses a list of files using regexps.
 func (p *RegexpMetadataParser) Parse(files []string) (book Book, parsed bool) {
 	if len(p.Regexps) != len(p.RegexpNames) {
 		log.Printf("RegexpMetadataParser: lengths of regexps and names are not equal")
@@ -75,8 +76,10 @@ func re2map(s string, r *regexp.Regexp) map[string]string {
 	return rmap
 }
 
+// EpubMetadataParser parses files using EPUB metadata.
 type EpubMetadataParser struct{}
 
+// Parse parses a list of files using EPUB metadata.
 func (*EpubMetadataParser) Parse(files []string) (book Book, parsed bool) {
 	for _, file := range files {
 		if path.Ext(strings.ToLower(file)) != ".epub" {


### PR DESCRIPTION
This allows metadata update commands to update the filename of the book.
Filesystem functions have been moved into fs.go,
and updateFilenames has been added to copy/move files into place.