### PR TITLE
Add a basic no-frills Docker image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+license
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+# First stage: Build the books binary
+FROM golang:alpine AS builder
+
+# Set the working directory and pull in the source
+WORKDIR /build
+COPY . /build
+
+# Install dependencies.
+RUN apk add --no-cache make build-base
+
+# Install Mage
+RUN go install github.com/magefile/mage@latest
+
+# Create a non-root user for later stages.
+RUN echo "nobody:x:65534:65534:nobody:/:/sbin/nologin" > ./passwd \
+    && echo "nobody:x:65534:" > ./group                           \
+    && chmod 644 ./passwd                                         \
+    && chmod 644 ./group
+
+# Build the application.
+RUN mage
+
+# Set executable permissions on the built binary.
+RUN chmod +x bin/books
+
+# Extract libraries to be copied into the Scratch image later.
+RUN ldd ./bin/books | tr -s '[:blank:]' '\n' | grep '^/' | xargs -I % sh -c 'mkdir -p $(dirname deps%); cp % deps%;'
+
+# Prepare a default configuration and template files.
+RUN mkdir -p config config/cache books_root \
+    && mv cmd/books/example_config.toml config/config.toml \
+    && mv templates config/ \
+    && chown -R 65534:65534 config books_root
+RUN echo -e "# Used by docker for storing books.\nroot = \"/books_root\"" > ./config/config.toml
+
+# Second stage: Create a minimal runtime environment
+FROM scratch
+
+# Set the working directory for the running container.
+WORKDIR /config
+
+# Copy over user/group definitions.
+COPY --from=builder /build/passwd /build/group /etc/
+
+# Now, the built binary and its dependencies.
+COPY --from=builder /build/bin/books /build/deps /
+
+# Grab our default config folder.
+COPY --from=builder /build/config /config
+COPY --from=builder /build/books_root /books_root
+
+# Create volumes for books root and config
+VOLUME /books_root
+VOLUME /config
+
+# Run the container as our previously created non-root user.
+USER 65534:65534
+
+# Expose port 80 for the application.
+EXPOSE 80
+
+ENTRYPOINT ["/books", "--config", "/config"]
+CMD ["serve", "-b", ":80"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  books:
+    image: books
+    container_name: books
+    ports:
+      - "8000:80"
+    volumes:
+      - books-config:/config  # Change this to a bind mount if you already have a config (or create the volume manually ahead of time)
+      - ~/books:/books_root  # Maintain the books root in the user's home directory as usual
+    restart: unless-stopped
+volumes:
+  books-config:


### PR DESCRIPTION
Based on Scratch, this is about as basic as it gets. Definitions for Docker Compose are also included.

This currently does not include Calibre's ebook-convert script, which means conversions will not be supported. (WIP; A larger Alpine-based image will be needed for this.)

By default, we listen on port 80 and expose port 8000 via Compose. The Compose file can be altered to bind mount various directories if you want to have host-system access and/or already have a library that you'd rather not import into a Docker volume.
